### PR TITLE
fix/ 두가지 모두 같을 때 저장되는 에러를 수정하기 위해 로직변경

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -22,16 +22,18 @@ export class AuthService {
   //회원가입
   async register(userInfo: SignUpDto): Promise<SignUpDto> {
     //이메일 및 닉네임 중복확인
-    const existUser = await this.userService.findByFields({
-      where: [{ nickname: userInfo.nickname }, { email: userInfo.email }],
+    const existNickname = await this.userService.findByFields({
+      where: { nickname: userInfo.nickname },
     });
-    if (existUser) {
-      if (existUser.nickname === userInfo.nickname)
-        throw new ConflictException('중복 닉네임');
 
-      if (existUser.email === userInfo.email)
-        throw new ConflictException('중복 이메일');
-    }
+    const existEmail = await this.userService.findByFields({
+      where: { email: userInfo.email },
+    });
+
+    if (existNickname) throw new ConflictException('중복 닉네임');
+
+    if (existEmail) throw new ConflictException('중복 이메일');
+
     //중복 확인 이후 유저 정보저장
     return await this.userService.saveUserInfo(userInfo);
   }


### PR DESCRIPTION
email과 nickname이 모두 같을 때 중복을 걸러내지 못하는 예외가 발생하여

각각 따로 findByFileds를 적용해 어느 것 하나라도 같을 때면 예외처리가 가능하게 끔 변경