### PR TITLE
fix/ muter업로드 예외 처리와, class-calidater예외 구분

### DIFF
--- a/common/exceptionFilter/http.exception.filter.ts
+++ b/common/exceptionFilter/http.exception.filter.ts
@@ -19,14 +19,17 @@ export class HttpExceptionFilter implements ExceptionFilter {
       | { error: string; statusCode: 400; message: string[] };
 
     if (typeof err !== 'string') {
-      // class-validator에서 발생한 에러 처리
       if (err.statusCode === 400) {
-        const [errorDetails] = err.message;
+        let errorDetails = err.message;
+        // class-validator에서 발생한 에러 처리
+        if (Array.isArray(err.message)) [errorDetails] = err.message;
+
         return res.status(status).json({
           errorMsg: '요청한 데이터 형식을 확인해주세요.',
           errorDetails,
         });
       }
+
       // JWT 인증 실패 에러 처리
       if (err.statusCode === 401) {
         return res.status(status).json({


### PR DESCRIPTION
multer업로드의 예외처리가 같은 exception filter에서 에러의 메시지를 반환할때,

class-validator와 message의 타입이 달라서 반환되는 errorDeatils의 에러를 수정하기 위해

if조건문으로 예외처리를 구분지어줌