### PR TITLE
test/manager Login 테스트 코드 수정

### DIFF
--- a/src/manager/manager.service.spec.ts
+++ b/src/manager/manager.service.spec.ts
@@ -134,19 +134,21 @@ describe('ManagerService', () => {
   });
 
   describe('managerLogin', () => {
+    const managerLoginDto: ManagerLoginDto = {
+      email: expect.any(String),
+      password: 'testpass',
+    };
+
+    const solt = Number(process.env.M_HASHING_SOLT);
+
+    const managerInfo = {
+      id: expect.any(Number),
+      email: expect.any(String),
+      password: expect.any(String),
+    };
+
     it('managerLogin success case', async () => {
-      const managerLoginDto: ManagerLoginDto = {
-        email: expect.any(String),
-        password: 'testpass',
-      };
-
-      const solt = Number(process.env.M_HASHING_SOLT);
-
-      const managerInfo = {
-        id: expect.any(Number),
-        email: expect.any(String),
-        password: await bcrypt.hash('testpass', solt),
-      };
+      managerInfo.password = await bcrypt.hash('testpass', solt);
 
       mockManagerRepository.findOne.mockResolvedValue(managerInfo);
 
@@ -167,11 +169,6 @@ describe('ManagerService', () => {
     });
 
     it('When there is no matching email', async () => {
-      const managerLoginDto: ManagerLoginDto = {
-        email: 'testemail@test.com',
-        password: 'testpass',
-      };
-
       mockManagerRepository.findOne.mockResolvedValue(undefined);
 
       try {
@@ -183,19 +180,7 @@ describe('ManagerService', () => {
     });
 
     it('When passwords do not match', async () => {
-      const managerLoginDto: ManagerLoginDto = {
-        email: expect.any(String),
-        password: 'testpass',
-      };
-
-      const solt = Number(process.env.M_HASHING_SOLT);
-
-      const managerInfo = {
-        id: expect.any(Number),
-        email: expect.any(String),
-        password: await bcrypt.hash('passtest', solt),
-      };
-
+      managerInfo.password = await bcrypt.hash('passtest', solt);
       mockManagerRepository.findOne.mockResolvedValue(managerInfo);
 
       try {


### PR DESCRIPTION
manager Login 테스트 코드 수정

여러 테스트 케이스를 가졌을 경우 공통된 블록범위 변수의 재선언을 삭제하고,

describe 한블럭 내에서 재사용 할 수 있도록 변경